### PR TITLE
Delete VITE_DOMAIN and VITE_API_BASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,3 @@ SMTP_PORT=<smtp-port>
 SMTP_USERNAME=<smtp-username>
 SMTP_PASSWORD=<smtp-password>
 SMTP_FROM_EMAIL=<smtp-from-email>
-
-# Frontend environment variables
-VITE_DOMAIN=local.trysourcetool.com

--- a/.env.example
+++ b/.env.example
@@ -31,5 +31,4 @@ SMTP_PASSWORD=<smtp-password>
 SMTP_FROM_EMAIL=<smtp-from-email>
 
 # Frontend environment variables
-VITE_API_BASE_URL=local.trysourcetool.com:8080
 VITE_DOMAIN=local.trysourcetool.com

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,6 @@
 FROM node:20-alpine AS frontend-builder
 WORKDIR /app/frontend
 
-# Add build-time arguments
-ARG VITE_API_BASE_URL
-ARG VITE_DOMAIN
-
-# Set environment variables for the build
-ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
-ENV VITE_DOMAIN=$VITE_DOMAIN
-
 COPY frontend/package.json frontend/yarn.lock ./
 RUN yarn install --frozen-lockfile
 COPY frontend/ ./

--- a/docker/cloud/Dockerfile
+++ b/docker/cloud/Dockerfile
@@ -1,13 +1,8 @@
 FROM node:20-alpine AS frontend-builder
 WORKDIR /app/frontend
 
-# Add build-time arguments
-ARG VITE_API_BASE_URL
-ARG VITE_DOMAIN
-
 # Set environment variables for the build
-ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
-ENV VITE_DOMAIN=$VITE_DOMAIN
+ENV VITE_IS_CLOUD_EDITION=true
 
 COPY frontend/package.json frontend/yarn.lock ./
 RUN yarn install --frozen-lockfile

--- a/frontend/app/api/instance.ts
+++ b/frontend/app/api/instance.ts
@@ -156,7 +156,8 @@ export const get: <T>(params: {
   }
 
   if (!res.ok) {
-    throw json as ErrorResponse;
+    const errorResponse = json as ErrorResponse;
+    throw new Error(errorResponse.detail || errorResponse.title || 'API Error');
   }
 
   throw new Error('Unknown error');

--- a/frontend/app/api/instance.ts
+++ b/frontend/app/api/instance.ts
@@ -152,8 +152,7 @@ export const get: <T>(params: {
   }
 
   if (!res.ok) {
-    const errorResponse = json as ErrorResponse;
-    throw new Error(errorResponse.detail || errorResponse.title || 'API Error');
+    throw json;
   }
 
   throw new Error('Unknown error');

--- a/frontend/app/api/instance.ts
+++ b/frontend/app/api/instance.ts
@@ -1,7 +1,6 @@
 import { ENVIRONMENTS } from '@/environments';
 import dayjs from 'dayjs';
 import { usersRefreshToken } from './modules/users';
-import { checkDomain } from '@/lib/checkDomain';
 
 type SuccessResponse = {
   code: 0;
@@ -85,9 +84,6 @@ class Api {
   }
 
   getParams(auth?: boolean) {
-    const domain = checkDomain();
-    console.log({ domain });
-
     const url = `/api/v1`;
 
     const headers = new Headers();

--- a/frontend/app/api/instance.ts
+++ b/frontend/app/api/instance.ts
@@ -87,7 +87,8 @@ class Api {
   getParams(auth?: boolean) {
     const domain = checkDomain();
     console.log({ domain });
-    const url = `${window.location.protocol}//${domain.isSourcetoolDomain && domain.subDomain ? `${domain.subDomain}.` : ''}${ENVIRONMENTS.API_BASE_URL}/api/v1`;
+
+    const url = `/api/v1`;
 
     const headers = new Headers();
 

--- a/frontend/app/components/common/domainProvider.tsx
+++ b/frontend/app/components/common/domainProvider.tsx
@@ -2,6 +2,7 @@ import { useAuth } from '@/hooks/use-auth';
 import { checkDomain } from '@/lib/checkDomain';
 import { useSelector } from '@/store';
 import { usersStore } from '@/store/modules/users';
+import { ENVIRONMENTS } from '@/environments';
 import {
   createContext,
   useEffect,
@@ -23,7 +24,7 @@ export const DomainProvider: FC<{ children: ReactNode }> = (props) => {
   }
 
   const account = useSelector(usersStore.selector.getMe);
-  const { isAuthChecked, isSourcetoolDomain, subDomain } = useAuth();
+  const { isAuthChecked, subDomain } = useAuth();
 
   const checkComplete = () => {
     setTimeout(() => {
@@ -93,7 +94,7 @@ export const DomainProvider: FC<{ children: ReactNode }> = (props) => {
     }
     isChecking.current = true;
 
-    if (isSourcetoolDomain) {
+    if (ENVIRONMENTS.IS_CLOUD_EDITION) {
       if (subDomain && subDomain !== 'auth') {
         handleAuthorizedRoute();
       }

--- a/frontend/app/components/common/websocket-controller.tsx
+++ b/frontend/app/components/common/websocket-controller.tsx
@@ -30,7 +30,7 @@ import { $path } from 'safe-routes';
 const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
   const dispatch = useDispatch();
   const { '*': path } = useParams();
-  const { subDomain, isSourcetoolDomain, environments } = useAuth();
+  const { environments } = useAuth();
   const currentPageId = useRef('');
   const currentSessionId = useRef('');
   const prevVisibilityStatus = useRef(!document.hidden);
@@ -344,12 +344,12 @@ const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
 export const WebSocketController = () => {
   const location = useLocation();
   const [isSocketReady, setIsSocketReady] = useState(false);
-  const { isAuthChecked, isSubDomainMatched, isSourcetoolDomain } = useAuth();
+  const { isAuthChecked, isSubDomainMatched } = useAuth();
 
   useEffect(() => {
     if (
       isAuthChecked === 'checked' &&
-      ((isSourcetoolDomain && isSubDomainMatched) || !isSourcetoolDomain) &&
+      ((ENVIRONMENTS.IS_CLOUD_EDITION && isSubDomainMatched) || !ENVIRONMENTS.IS_CLOUD_EDITION) &&
       location.pathname.match(/^\/pages\/.*$/)
     ) {
       setIsSocketReady(true);
@@ -357,7 +357,6 @@ export const WebSocketController = () => {
   }, [
     location.pathname,
     isSubDomainMatched,
-    isSourcetoolDomain,
     isAuthChecked,
   ]);
 

--- a/frontend/app/components/common/websocket-controller.tsx
+++ b/frontend/app/components/common/websocket-controller.tsx
@@ -30,7 +30,6 @@ import { $path } from 'safe-routes';
 const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
   const dispatch = useDispatch();
   const { '*': path } = useParams();
-  const { environments } = useAuth();
   const currentPageId = useRef('');
   const currentSessionId = useRef('');
   const prevVisibilityStatus = useRef(!document.hidden);
@@ -41,8 +40,8 @@ const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
   const isInitialLoading = useRef(false);
   const socketUrl = useMemo(
     () =>
-      `${environments === 'local' ? 'ws' : 'wss'}://${window.location.host}/ws`,
-    [environments],
+      `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws`,
+    [],
   );
 
   const pageId = useSelector(

--- a/frontend/app/components/common/websocket-controller.tsx
+++ b/frontend/app/components/common/websocket-controller.tsx
@@ -41,12 +41,8 @@ const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
   const isInitialLoading = useRef(false);
   const socketUrl = useMemo(
     () =>
-      `${
-        environments === 'local' ? 'ws' : 'wss'
-      }://${isSourcetoolDomain && subDomain ? `${subDomain}.` : ''}${
-        ENVIRONMENTS.API_BASE_URL
-      }/ws`,
-    [subDomain, environments, isSourcetoolDomain],
+      `${environments === 'local' ? 'ws' : 'wss'}://${window.location.host}/ws`,
+    [environments],
   );
 
   const pageId = useSelector(

--- a/frontend/app/components/layout/app-external-layout.tsx
+++ b/frontend/app/components/layout/app-external-layout.tsx
@@ -49,6 +49,7 @@ import { Avatar, AvatarFallback } from '../ui/avatar';
 import { useAuth } from '@/hooks/use-auth';
 import { usersStore } from '@/store/modules/users';
 import { useDispatch, useSelector } from '@/store';
+import { ENVIRONMENTS } from '@/environments';
 
 export function AppExternalLayout(props: PropsWithChildren) {
   const dispatch = useDispatch();
@@ -59,7 +60,6 @@ export function AppExternalLayout(props: PropsWithChildren) {
     isSubDomainMatched,
     isAuthChecked,
     handleNoAuthRoute,
-    isSourcetoolDomain,
   } = useAuth();
   const user = useSelector(usersStore.selector.getMe);
   const { t } = useTranslation('common');
@@ -78,19 +78,19 @@ export function AppExternalLayout(props: PropsWithChildren) {
   useEffect(() => {
     if (
       isAuthChecked === 'checked' &&
-      isSourcetoolDomain &&
+      ENVIRONMENTS.IS_CLOUD_EDITION &&
       !isSubDomainMatched
     ) {
       handleNoAuthRoute();
-    } else if (isAuthChecked === 'checked' && !isSourcetoolDomain && !user) {
+    } else if (isAuthChecked === 'checked' && !ENVIRONMENTS.IS_CLOUD_EDITION && !user) {
       handleNoAuthRoute();
     }
   }, [isSubDomainMatched, isAuthChecked, handleNoAuthRoute]);
 
   return (isAuthChecked === 'checked' &&
-    isSourcetoolDomain &&
+    ENVIRONMENTS.IS_CLOUD_EDITION &&
     isSubDomainMatched) ||
-    (isAuthChecked === 'checked' && !isSourcetoolDomain && user) ? (
+    (isAuthChecked === 'checked' && !ENVIRONMENTS.IS_CLOUD_EDITION && user) ? (
     <>
       <Sidebar collapsible="icon">
         <SidebarHeader>

--- a/frontend/app/components/layout/app-preview-layout.tsx
+++ b/frontend/app/components/layout/app-preview-layout.tsx
@@ -21,6 +21,7 @@ import { useDispatch, useSelector } from '@/store';
 import { pagesStore } from '@/store/modules/pages';
 import { usersStore } from '@/store/modules/users';
 import { environmentsStore } from '@/store/modules/environments';
+import { ENVIRONMENTS } from '@/environments';
 
 export function AppPreviewLayout(props: PropsWithChildren) {
   const isInitialLoading = useRef(false);
@@ -29,7 +30,6 @@ export function AppPreviewLayout(props: PropsWithChildren) {
     isSubDomainMatched,
     isAuthChecked,
     handleNoAuthRoute,
-    isSourcetoolDomain,
   } = useAuth();
   const dispatch = useDispatch();
   const user = useSelector(usersStore.selector.getMe);
@@ -40,7 +40,7 @@ export function AppPreviewLayout(props: PropsWithChildren) {
   useEffect(() => {
     if (
       isAuthChecked === 'checked' &&
-      isSourcetoolDomain &&
+      ENVIRONMENTS.IS_CLOUD_EDITION &&
       !isSubDomainMatched
     ) {
       handleNoAuthRoute();
@@ -98,15 +98,15 @@ export function AppPreviewLayout(props: PropsWithChildren) {
         }
         isInitialLoading.current = false;
       })();
-    } else if (isAuthChecked === 'checked' && !isSourcetoolDomain && !user) {
+    } else if (isAuthChecked === 'checked' && !ENVIRONMENTS.IS_CLOUD_EDITION && !user) {
       handleNoAuthRoute();
     }
   }, [dispatch]);
 
   return (isAuthChecked === 'checked' &&
-    isSourcetoolDomain &&
+    ENVIRONMENTS.IS_CLOUD_EDITION &&
     isSubDomainMatched) ||
-    (isAuthChecked === 'checked' && !isSourcetoolDomain && user) ? (
+    (isAuthChecked === 'checked' && !ENVIRONMENTS.IS_CLOUD_EDITION && user) ? (
     <>
       <Sidebar collapsible="icon">
         <SidebarHeader>

--- a/frontend/app/environments.ts
+++ b/frontend/app/environments.ts
@@ -1,5 +1,4 @@
 export const ENVIRONMENTS = {
-  API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
   DOMAIN: import.meta.env.VITE_DOMAIN,
   MODE: import.meta.env.MODE,
 };

--- a/frontend/app/environments.ts
+++ b/frontend/app/environments.ts
@@ -1,4 +1,4 @@
 export const ENVIRONMENTS = {
-  DOMAIN: import.meta.env.VITE_DOMAIN,
   MODE: import.meta.env.MODE,
+  IS_CLOUD_EDITION: import.meta.env.VITE_IS_CLOUD_EDITION === 'true',
 };

--- a/frontend/app/lib/checkDomain.ts
+++ b/frontend/app/lib/checkDomain.ts
@@ -2,42 +2,21 @@ import { ENVIRONMENTS } from '@/environments';
 
 export function checkDomain() {
   const returnValue: {
-    isSourcetoolDomain: boolean;
     subDomain: string | null;
-    environments: 'production' | 'staging' | 'local' | null;
+    environments: 'production' | 'staging' | 'local';
   } = {
-    isSourcetoolDomain: false,
     subDomain: null,
-    environments: null,
+    environments: ENVIRONMENTS.MODE === 'development' ? 'local' : 'production',
   };
 
-  const hostname = window.location.hostname;
-  const isSourcetoolDomain = ENVIRONMENTS.DOMAIN.match(
-    /^((staging|local)\.)?trysourcetool\.com$/,
-  );
-
-  returnValue.isSourcetoolDomain = !!isSourcetoolDomain;
-
-  if (isSourcetoolDomain) {
-    const subdomainRegex = new RegExp(
-      `^(?:http[s]?:\\/\\/)?([^.]+)\\.${ENVIRONMENTS.DOMAIN}`,
-    );
-    const matches = hostname.match(subdomainRegex);
-    if (matches && matches[1]) {
-      returnValue.subDomain = matches[1];
-    }
-    if (isSourcetoolDomain[2] === 'staging') {
-      returnValue.environments = 'staging';
-    } else if (isSourcetoolDomain[2] === 'local') {
-      returnValue.environments = 'local';
-    } else {
-      returnValue.environments = 'production';
-    }
-  } else {
-    if (ENVIRONMENTS.DOMAIN.includes('localhost')) {
-      returnValue.environments = 'local';
-    } else {
-      returnValue.environments = 'production';
+  if (ENVIRONMENTS.IS_CLOUD_EDITION) {
+    const hostname = window.location.hostname;
+    const parts = hostname.split('.');
+    if (parts.length > 2) {
+      returnValue.subDomain = parts[0];
+      if (parts[parts.length - 2] === 'staging') {
+        returnValue.environments = 'staging';
+      }
     }
   }
 


### PR DESCRIPTION
## Background
Previously, our Docker build process required customer-specific environment variables (`VITE_API_BASE_URL` and `VITE_DOMAIN`) to be set at build time. This approach created challenges when distributing our Cloud Edition (CE) as Docker images, as we couldn't pre-configure these variables for each customer during the build phase.

## Changes
- Removed build-time environment variables (`VITE_API_BASE_URL` and `VITE_DOMAIN`) from Docker configurations
- Introduced a new environment flag `VITE_IS_CLOUD_EDITION` to distinguish Cloud Edition deployments
- Simplified API URL handling to use relative paths (`/api/v1`) instead of constructing absolute URLs
- Updated WebSocket connection logic to use the current host instead of environment-specific domains
- Streamlined domain checking logic to focus on Cloud Edition specific behaviors
- Removed redundant domain validation and simplified routing logic