### PR TITLE
fix: use millisecond timestamp for widget update

### DIFF
--- a/frontend/app/store/modules/widgets.ts
+++ b/frontend/app/store/modules/widgets.ts
@@ -426,7 +426,7 @@ const slice = createSlice({
 
           if (!hasError) {
             widget.widget.form.value = true;
-            state.updateAt = dayjs().unix();
+            state.updateAt = dayjs().valueOf();
             state.isWidgetWaiting = true;
           }
         } else {
@@ -449,7 +449,7 @@ const slice = createSlice({
               }
             }
             if (!hasParentForm) {
-              state.updateAt = dayjs().unix();
+              state.updateAt = dayjs().valueOf();
               state.isWidgetWaiting = true;
             }
           }


### PR DESCRIPTION
## Problem:
When rapidly clicking interactive elements (specifically observed with table rows) multiple times within the same second, the UI could get stuck indefinitely in a loading state. The expected rerunPage WebSocket request was not being sent after the initial click in the sequence.

## Root Cause:
The state timestamp (updateAt in widgets.ts) used to trigger the rerunPage request via a useEffect hook in websocket-controller.tsx was generated using dayjs().unix(). This function returns a Unix timestamp with second-level precision.
When multiple clicks occurred within the same second, dayjs().unix() produced the same timestamp value for each click. The useEffect hook only triggers when its dependency (updateAt) changes. Since the timestamp value wasn't changing between clicks within the same second, the hook didn't re-run, and subsequent rerunPage requests were not initiated.
However, the loading state (isWidgetWaiting) was being set to true on each click. Because no new rerunPage request was sent after the first one in the sequence, no corresponding scriptFinished message was received from the server to reset isWidgetWaiting to false, leaving the UI stuck in the loading state.

## Solution:
The timestamp generation in the setWidgetValue reducer within widgets.ts was changed from dayjs().unix() to dayjs().valueOf(). This method returns a timestamp with millisecond-level precision.
This ensures that even rapid clicks within the same second generate unique timestamps for updateAt. Consequently, the useEffect hook now correctly detects a change on every click, reliably triggering the handleRerunPage function and sending the necessary rerunPage request to the server. This allows the loading state to be properly managed and cleared upon receiving the server's response.