### PR TITLE
Refactor session handling and improve frontend websocket stability

### DIFF
--- a/backend/dto/session.go
+++ b/backend/dto/session.go
@@ -9,7 +9,7 @@ type Session struct {
 	ID             string
 	OrganizationID string
 	UserID         string
-	PageID         string
+	APIKeyID       string
 	HostInstanceID string
 	CreatedAt      int64
 	UpdatedAt      int64
@@ -25,7 +25,7 @@ func SessionFromModel(session *model.Session) *Session {
 		ID:             session.ID.String(),
 		OrganizationID: session.OrganizationID.String(),
 		UserID:         session.UserID.String(),
-		PageID:         session.PageID.String(),
+		APIKeyID:       session.APIKeyID.String(),
 		HostInstanceID: session.HostInstanceID.String(),
 		CreatedAt:      session.CreatedAt.Unix(),
 		UpdatedAt:      session.UpdatedAt.Unix(),

--- a/backend/migrations/000017_create_function_validate_session.up.sql
+++ b/backend/migrations/000017_create_function_validate_session.up.sql
@@ -3,7 +3,7 @@ BEGIN;
 CREATE OR REPLACE FUNCTION validate_session()
 RETURNS TRIGGER AS $$
 DECLARE
-    page_org_id UUID;
+    api_key_org_id UUID;
     host_instance_org_id UUID;
 BEGIN
     IF NOT EXISTS (
@@ -15,12 +15,12 @@ BEGIN
         RAISE EXCEPTION 'User % must belong to organization % to create a session', NEW.user_id, NEW.organization_id;
     END IF;
 
-    SELECT organization_id INTO page_org_id
-    FROM "page"
-    WHERE id = NEW.page_id;
+    SELECT organization_id INTO api_key_org_id
+    FROM "api_key"
+    WHERE id = NEW.api_key_id;
 
-    IF page_org_id != NEW.organization_id THEN
-        RAISE EXCEPTION 'Page % must belong to organization % to create a session', NEW.page_id, NEW.organization_id;
+    IF api_key_org_id != NEW.organization_id THEN
+        RAISE EXCEPTION 'API key % must belong to organization % to create a session', NEW.api_key_id, NEW.organization_id;
     END IF;
 
     SELECT organization_id INTO host_instance_org_id

--- a/backend/migrations/000018_create_table_session.up.sql
+++ b/backend/migrations/000018_create_table_session.up.sql
@@ -4,13 +4,13 @@ CREATE TABLE "session" (
   "id"               UUID        NOT NULL,
   "organization_id"  UUID        NOT NULL,
   "user_id"          UUID        NOT NULL,
-  "page_id"          UUID        NOT NULL,
+  "api_key_id"       UUID        NOT NULL,
   "host_instance_id" UUID        NOT NULL,
   "created_at"       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   "updated_at"       TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE CASCADE,
   FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE,
-  FOREIGN KEY ("page_id") REFERENCES "page"("id") ON DELETE CASCADE,
+  FOREIGN KEY ("api_key_id") REFERENCES "api_key"("id") ON DELETE CASCADE,
   FOREIGN KEY ("host_instance_id") REFERENCES "host_instance"("id") ON DELETE CASCADE,
   PRIMARY KEY ("id")
 );

--- a/backend/model/session.go
+++ b/backend/model/session.go
@@ -13,7 +13,7 @@ type Session struct {
 	ID             uuid.UUID `db:"id"`
 	OrganizationID uuid.UUID `db:"organization_id"`
 	UserID         uuid.UUID `db:"user_id"`
-	PageID         uuid.UUID `db:"page_id"`
+	APIKeyID       uuid.UUID `db:"api_key_id"`
 	HostInstanceID uuid.UUID `db:"host_instance_id"`
 	CreatedAt      time.Time `db:"created_at"`
 	UpdatedAt      time.Time `db:"updated_at"`

--- a/backend/session/store.go
+++ b/backend/session/store.go
@@ -46,7 +46,7 @@ func (s *StoreCE) buildQuery(ctx context.Context, opts ...storeopts.SessionOptio
 		`s."id"`,
 		`s."organization_id"`,
 		`s."user_id"`,
-		`s."page_id"`,
+		`s."api_key_id"`,
 		`s."host_instance_id"`,
 		`s."created_at"`,
 		`s."updated_at"`,
@@ -72,14 +72,14 @@ func (s *StoreCE) Create(ctx context.Context, m *model.Session) error {
 			`"id"`,
 			`"organization_id"`,
 			`"user_id"`,
-			`"page_id"`,
+			`"api_key_id"`,
 			`"host_instance_id"`,
 		).
 		Values(
 			m.ID,
 			m.OrganizationID,
 			m.UserID,
-			m.PageID,
+			m.APIKeyID,
 			m.HostInstanceID,
 		).
 		RunWith(s.db).

--- a/backend/storeopts/page.go
+++ b/backend/storeopts/page.go
@@ -64,7 +64,8 @@ func (o pageBySessionIDOption) isPageOption() {}
 
 func (o pageBySessionIDOption) Apply(b sq.SelectBuilder) sq.SelectBuilder {
 	return b.
-		InnerJoin(`"session" s ON s."page_id" = p."id"`).
+		InnerJoin(`"api_key" ak ON ak."id" = p."api_key_id"`).
+		InnerJoin(`"session" s ON s."api_key_id" = ak."id"`).
 		Where(sq.Eq{`s."id"`: o.id})
 }
 

--- a/backend/ws/service.go
+++ b/backend/ws/service.go
@@ -112,7 +112,7 @@ func (s *ServiceCE) InitializeClient(ctx context.Context, msg *websocketv1.Messa
 		sess = &model.Session{
 			ID:             uuid.Must(uuid.NewV4()),
 			OrganizationID: page.OrganizationID,
-			PageID:         page.ID,
+			APIKeyID:       page.APIKeyID,
 			HostInstanceID: onlineHostInstance.ID,
 			UserID:         currentUser.ID,
 		}
@@ -378,7 +378,7 @@ func (s *ServiceCE) CloseSession(ctx context.Context, msg *websocketv1.Message) 
 		return err
 	}
 
-	_, err = s.Store.Page().Get(ctx, storeopts.PageByID(sess.PageID), storeopts.PageBySessionID(sess.ID))
+	_, err = s.Store.Page().Get(ctx, storeopts.PageByAPIKeyID(sess.APIKeyID), storeopts.PageBySessionID(sess.ID))
 	if err != nil {
 		return err
 	}

--- a/frontend/app/components/common/websocket-controller.tsx
+++ b/frontend/app/components/common/websocket-controller.tsx
@@ -10,6 +10,7 @@ import {
   MessageSchema,
   type CloseSessionJson,
   type InitializeClientJson,
+  type RerunPageJson,
 } from '@/pb/ts/websocket/v1/message_pb';
 import {
   create,
@@ -39,6 +40,9 @@ const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
     !document.hidden,
   );
   const isInitialLoading = useRef(false);
+  const inactiveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
   const socketUrl = useMemo(
     () =>
       `${
@@ -113,6 +117,10 @@ const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
   });
 
   const handleCloseSession = useCallback(() => {
+    if (inactiveTimeoutRef.current) {
+      clearTimeout(inactiveTimeoutRef.current);
+      inactiveTimeoutRef.current = null;
+    }
     console.log('handleCloseSession');
     sendMessage(
       toBinary(
@@ -128,6 +136,7 @@ const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
         }),
       ),
     );
+    currentSessionId.current = '';
   }, [sendMessage]);
 
   useEffect(() => {
@@ -140,12 +149,18 @@ const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
     return () => {
       window.removeEventListener('beforeunload', handleCloseSession);
       window.removeEventListener('visibilitychange', handleVisibilityChange);
+      if (inactiveTimeoutRef.current) {
+        clearTimeout(inactiveTimeoutRef.current);
+      }
     };
-  }, [handleCloseSession]);
+  }, [isVisibilityStatus, handleCloseSession]);
 
   useEffect(() => {
     (async () => {
-      if ((!pageId && !currentPageId.current) || isInitialLoading.current) {
+      if (!pageId && !currentPageId.current) {
+        return;
+      }
+      if (isInitialLoading.current && currentPageId.current === pageId) {
         return;
       }
       isInitialLoading.current = true;
@@ -196,42 +211,29 @@ const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
               create(MessageSchema, {
                 id: uuidv4(),
                 type: {
-                  case: 'initializeClient',
+                  case: 'rerunPage',
                   value: {
+                    sessionId: currentSessionId.current,
                     pageId: pageId,
-                  } satisfies InitializeClientJson,
+                    states: [],
+                  } satisfies RerunPageJson,
                 },
               }),
             ),
           );
-
           currentPageId.current = pageId;
         }
-      }
-
-      if (!pageId && currentPageId.current) {
-        console.log('CLEAR WIDGETS');
+      } else if (currentPageId.current) {
+        console.log('CLEAR WIDGETS AND DISABLE CONTROLLER');
         dispatch(widgetsStore.actions.clearWidgets());
         dispatch(pagesStore.actions.clearException());
-        sendMessage(
-          toBinary(
-            MessageSchema,
-            create(MessageSchema, {
-              id: uuidv4(),
-              type: {
-                case: 'closeSession',
-                value: {
-                  sessionId: currentSessionId.current,
-                } satisfies CloseSessionJson,
-              },
-            }),
-          ),
-        );
-        currentSessionId.current = '';
+        handleCloseSession();
+        currentPageId.current = '';
         setTimeout(() => {
           onDisable();
         }, 1000);
       }
+      isInitialLoading.current = false;
     })();
   }, [pageId]);
 
@@ -293,54 +295,61 @@ const WebSocketBlock = ({ onDisable }: { onDisable: () => void }) => {
         return;
       }
       if (isVisibilityStatus && !exception) {
-        const resultAction = await dispatch(
-          hostInstancesStore.asyncActions.getHostInstancePing({
-            pageId,
-          }),
-        );
-        if (
-          hostInstancesStore.asyncActions.getHostInstancePing.rejected.match(
-            resultAction,
-          )
-        ) {
-          currentSessionId.current = '';
-          navigate($path('/error/hostInstancePingError'));
-          return;
+        console.log('Tab became active');
+        if (inactiveTimeoutRef.current) {
+          console.log('Clearing inactivity timer');
+          clearTimeout(inactiveTimeoutRef.current);
+          inactiveTimeoutRef.current = null;
         }
 
-        console.log('currentSessionId.current', currentSessionId.current, {
-          id: uuidv4(),
-          type: {
-            case: 'initializeClient',
-            value: {
-              pageId: pageId,
-              sessionId: currentSessionId.current,
-            } satisfies InitializeClientJson,
-          },
-        });
-
-        sendMessage(
-          toBinary(
-            MessageSchema,
-            create(MessageSchema, {
-              id: uuidv4(),
-              type: {
-                case: 'initializeClient',
-                value: {
-                  pageId: pageId,
-                  sessionId: currentSessionId.current,
-                } satisfies InitializeClientJson,
-              },
+        if (!currentSessionId.current) {
+          console.log('Re-initializing client after becoming active');
+          const resultAction = await dispatch(
+            hostInstancesStore.asyncActions.getHostInstancePing({
+              pageId,
             }),
-          ),
-        );
+          );
+          if (
+            hostInstancesStore.asyncActions.getHostInstancePing.rejected.match(
+              resultAction,
+            )
+          ) {
+            currentSessionId.current = '';
+            navigate($path('/error/hostInstancePingError'));
+            return;
+          }
 
-        currentPageId.current = pageId;
+          sendMessage(
+            toBinary(
+              MessageSchema,
+              create(MessageSchema, {
+                id: uuidv4(),
+                type: {
+                  case: 'initializeClient',
+                  value: {
+                    pageId: pageId,
+                    sessionId: currentSessionId.current,
+                  } satisfies InitializeClientJson,
+                },
+              }),
+            ),
+          );
+        } else {
+          console.log('Session still active, no need to re-initialize');
+        }
       } else {
-        handleCloseSession();
+        console.log('Tab became inactive');
+        if (!inactiveTimeoutRef.current && currentSessionId.current) {
+          console.log(`Starting inactivity timer (${INACTIVITY_TIMEOUT_MS}ms)`);
+          inactiveTimeoutRef.current = setTimeout(() => {
+            console.log('Inactivity timer expired, closing session');
+            handleCloseSession();
+            inactiveTimeoutRef.current = null;
+          }, INACTIVITY_TIMEOUT_MS);
+        }
       }
     })();
-  }, [isVisibilityStatus]);
+  }, [isVisibilityStatus, pageId, exception]);
 
   return <></>;
 };


### PR DESCRIPTION
## Refactor Backend Session Management and Frontend WebSocket Handling

### Background

This PR addresses several aspects of session management and WebSocket communication to improve stability, flexibility, and user experience:

1.  **Backend Session Coupling:** Previously, backend sessions (`session` table) were directly tied to a specific `page_id`. This limited the flexibility of a session, potentially requiring new sessions even when navigating between pages associated with the same API Key.
2.  **Frontend WebSocket Churn:** The frontend WebSocket controller previously re-established connections (`closeSession` followed by `initializeClient`) on every page navigation within the `/pages/` routes. This caused unnecessary overhead and potential delays.
3.  **Inactivity Handling:** Simply switching browser tabs would immediately trigger a `closeSession`, which is often not the desired behavior. A more graceful handling of user inactivity was needed.
4.  **Frontend Stability:** Some `useEffect` hooks had missing dependencies, potentially leading to stale closures and unexpected behavior with event listeners and state updates.

The goal of these changes is to:
*   Decouple backend sessions from specific pages, linking them to API Keys instead.
*   Maintain a stable WebSocket connection during user navigation within the application's core pages.
*   Implement a timeout mechanism to close sessions only after a reasonable period of inactivity.
*   Improve the robustness of the frontend WebSocket controller logic.

### Changes

#### Backend

*   **Session Model Decoupling:**
    *   Modified the `session` table schema (migration `000018`): Replaced the `page_id` column with `api_key_id`.
    *   Updated the `validate_session` database trigger function (migration `000017`) to validate against `api_key_id` belonging to the correct organization instead of `page_id`.
    *   Updated the Go `Session` model (`backend/model/session.go`) and DTO (`backend/dto/session.go`) to reflect the schema change (`PageID` -> `APIKeyID`).
    *   Updated the session store (`backend/session/store.go`) SQL queries (`buildQuery`, `Create`) to use `api_key_id`.
    *   Updated store options (`backend/storeopts/page.go`) for `pageBySessionIDOption` to correctly join through the `api_key` table.
    *   Modified the WebSocket service (`backend/ws/service.go`):
        *   `InitializeClient`: Now associates the created session with `page.APIKeyID`.
        *   `CloseSession`: Validates the page lookup using `storeopts.PageByAPIKeyID`.

#### Frontend (`frontend/app/components/common/websocket-controller.tsx`)

*   **Page Transition Refactoring:**
    *   Introduced using the `rerunPage` message for navigation between different routes within `/pages/...`. This maintains the existing WebSocket session.
    *   Removed the previous logic of calling `closeSession` and `initializeClient` during these intra-app page transitions.
*   **Inactivity Timeout Implementation:**
    *   Added a timer (`INACTIVITY_TIMEOUT_MS`, currently set to 10 minutes) that starts when the browser tab becomes inactive.
    *   If the tab remains inactive for the duration of the timeout, `handleCloseSession` is called to terminate the session.
    *   If the tab becomes active again *before* the timeout, the timer is cleared.
    *   If the tab becomes active again *after* the timeout (session was closed), `initializeClient` is called to establish a new session.
*   **Lifecycle and Event Listener Improvements:**
    *   Corrected the dependency array for the `useEffect` hook managing `visibilitychange` and `beforeunload` event listeners to `[isVisibilityStatus, handleCloseSession]`, ensuring listeners always use the latest state and callbacks.
    *   Updated the dependency array for the `useEffect` handling visibility status changes and re-initialization logic to `[isVisibilityStatus, pageId, exception]`.
*   **Cleanup Logic:**
    *   Ensured `handleCloseSession` is still called correctly when navigating *away* from `/pages/` routes (e.g., to `/dashboard`) or during `beforeunload`.
    *   Refined timer clearing logic within `handleCloseSession` and the component unmount cleanup function.

### Testing Considerations

*   Verify page navigation within `/pages/` routes maintains the WebSocket connection and updates the page content via `rerunPage`.
*   Verify navigating away from `/pages/` closes the session correctly.
*   Test the inactivity timeout: leave a tab inactive for >10 minutes, confirm `closeSession` occurs, then reactivate the tab and confirm `initializeClient` establishes a new session.
*   Test activating the tab *before* the timeout expires, confirming the session remains active.
*   Verify closing the browser tab/window triggers `closeSession`.
*   Monitor browser console for errors and WebSocket message flow during these scenarios.