### PR TITLE
Fix subdomain detection

### DIFF
--- a/backend/internal/subdomain.go
+++ b/backend/internal/subdomain.go
@@ -9,9 +9,19 @@ func GetSubdomainFromHost(host string) (string, error) {
 	if host == "" {
 		return "", errors.New("empty host")
 	}
+
+	// Strip port if present
+	host = strings.Split(host, ":")[0]
+
 	parts := strings.Split(host, ".")
 	if len(parts) < 2 {
 		return "", errors.New("invalid host format")
 	}
+
+	// No subdomain if only domain and tld are present
+	if len(parts) == 2 {
+		return "", nil
+	}
+
 	return parts[0], nil
 }

--- a/backend/internal/subdomain_test.go
+++ b/backend/internal/subdomain_test.go
@@ -1,0 +1,28 @@
+package internal
+
+import "testing"
+
+func TestGetSubdomainFromHost(t *testing.T) {
+	tests := []struct {
+		host    string
+		want    string
+		wantErr bool
+	}{
+		{"org.trysourcetool.com", "org", false},
+		{"org.trysourcetool.com:8080", "org", false},
+		{"trysourcetool.com", "", false},
+		{"trysourcetool.com:8080", "", false},
+		{"localhost", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := GetSubdomainFromHost(tt.host)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("GetSubdomainFromHost(%q) error = %v, wantErr %v", tt.host, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("GetSubdomainFromHost(%q) = %q, want %q", tt.host, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- handle hosts without subdomain properly
- add tests for subdomain parsing

## Testing
- `go test ./internal -run TestGetSubdomainFromHost -count=1` *(fails: go toolchain download blocked)*