### PR TITLE
Fix subdomain parsing

### DIFF
--- a/backend/internal/subdomain.go
+++ b/backend/internal/subdomain.go
@@ -9,9 +9,19 @@ func GetSubdomainFromHost(host string) (string, error) {
 	if host == "" {
 		return "", errors.New("empty host")
 	}
+
+	// Strip port if present
+	host = strings.SplitN(host, ":", 2)[0]
+
 	parts := strings.Split(host, ".")
 	if len(parts) < 2 {
 		return "", errors.New("invalid host format")
 	}
+
+	// No subdomain if only domain and tld are present
+	if len(parts) == 2 {
+		return "", nil
+	}
+
 	return parts[0], nil
 }

--- a/backend/internal/subdomain.go
+++ b/backend/internal/subdomain.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"errors"
+	"net"
 	"strings"
 )
 
@@ -11,7 +12,9 @@ func GetSubdomainFromHost(host string) (string, error) {
 	}
 
 	// Strip port if present
-	host = strings.SplitN(host, ":", 2)[0]
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
 
 	parts := strings.Split(host, ".")
 	if len(parts) < 2 {

--- a/backend/internal/subdomain_test.go
+++ b/backend/internal/subdomain_test.go
@@ -1,0 +1,28 @@
+package internal
+
+import "testing"
+
+func TestGetSubdomainFromHost(t *testing.T) {
+	tests := []struct {
+		host    string
+		want    string
+		wantErr bool
+	}{
+		{"org.trysourcetool.com", "org", false},
+		{"org.trysourcetool.com:8080", "org", false},
+		{"trysourcetool.com", "", false},
+		{"trysourcetool.com:8080", "", false},
+		{"localhost", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := GetSubdomainFromHost(tt.host)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("GetSubdomainFromHost(%q) error = %v, wantErr %v", tt.host, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("GetSubdomainFromHost(%q) = %q, want %q", tt.host, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- better host port stripping

## Testing
- `go test ./internal -run TestGetSubdomainFromHost -count=1` *(fails: go toolchain download blocked)*
