### PR TITLE
Improve parallelism in core tests

### DIFF
--- a/backend/internal/core/hostinstance_test.go
+++ b/backend/internal/core/hostinstance_test.go
@@ -13,9 +13,13 @@ func TestHostInstanceStatus_String(t *testing.T) {
 		{HostInstanceStatus(100), "unknown"},
 	}
 	for _, c := range cases {
-		if got := c.status.String(); got != c.expected {
-			t.Errorf("HostInstanceStatus(%d).String() = %q, want %q", c.status, got, c.expected)
-		}
+		c := c
+		t.Run(c.expected, func(t *testing.T) {
+			t.Parallel()
+			if got := c.status.String(); got != c.expected {
+				t.Errorf("HostInstanceStatus(%d).String() = %q, want %q", c.status, got, c.expected)
+			}
+		})
 	}
 }
 
@@ -30,8 +34,12 @@ func TestHostInstanceStatusFromString(t *testing.T) {
 		{"invalid", HostInstanceStatusUnknown},
 	}
 	for _, c := range cases {
-		if got := HostInstanceStatusFromString(c.input); got != c.expected {
-			t.Errorf("HostInstanceStatusFromString(%q) = %v, want %v", c.input, got, c.expected)
-		}
+		c := c
+		t.Run(c.input, func(t *testing.T) {
+			t.Parallel()
+			if got := HostInstanceStatusFromString(c.input); got != c.expected {
+				t.Errorf("HostInstanceStatusFromString(%q) = %v, want %v", c.input, got, c.expected)
+			}
+		})
 	}
 }

--- a/backend/internal/core/permission_test.go
+++ b/backend/internal/core/permission_test.go
@@ -41,7 +41,9 @@ func TestCanPerform(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := CanPerform(tt.role, tt.op)
 			if got != tt.want {
 				t.Errorf("CanPerform(%q, %q) = %v, want %v", tt.role, tt.op, got, tt.want)

--- a/backend/internal/core/user_test.go
+++ b/backend/internal/core/user_test.go
@@ -14,9 +14,13 @@ func TestUserOrganizationRole_String(t *testing.T) {
 		{UserOrganizationRole(100), "unknown"},
 	}
 	for _, c := range cases {
-		if got := c.role.String(); got != c.expected {
-			t.Errorf("UserOrganizationRole(%d).String() = %q, want %q", c.role, got, c.expected)
-		}
+		c := c
+		t.Run(c.expected, func(t *testing.T) {
+			t.Parallel()
+			if got := c.role.String(); got != c.expected {
+				t.Errorf("UserOrganizationRole(%d).String() = %q, want %q", c.role, got, c.expected)
+			}
+		})
 	}
 }
 
@@ -32,8 +36,12 @@ func TestUserOrganizationRoleFromString(t *testing.T) {
 		{"invalid", UserOrganizationRoleUnknown},
 	}
 	for _, c := range cases {
-		if got := UserOrganizationRoleFromString(c.input); got != c.expected {
-			t.Errorf("UserOrganizationRoleFromString(%q) = %v, want %v", c.input, got, c.expected)
-		}
+		c := c
+		t.Run(c.input, func(t *testing.T) {
+			t.Parallel()
+			if got := UserOrganizationRoleFromString(c.input); got != c.expected {
+				t.Errorf("UserOrganizationRoleFromString(%q) = %v, want %v", c.input, got, c.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- add t.Parallel to each subtest in core tests
- prevent variable capture when ranging

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.0)*
- `go test ./...` *(fails: could not download toolchain)*